### PR TITLE
Added missing variable declaration for downcode

### DIFF
--- a/parameterize.js
+++ b/parameterize.js
@@ -91,7 +91,7 @@ Downcoder.Initialize = function()
     Downcoder.regex = new RegExp('[' + Downcoder.chars + ']|[^' + Downcoder.chars + ']+','g') ;
 }
  
-downcode= function( slug )
+var downcode = function( slug )
 {
     Downcoder.Initialize() ;
     var downcoded =""


### PR DESCRIPTION
The latest version throws an error at line 94 because variable downcode is not declared. This patch fixes said error.
